### PR TITLE
Fix broken name detection of zip file

### DIFF
--- a/common/install.sh
+++ b/common/install.sh
@@ -1,7 +1,7 @@
 UNSELECTED_MODE=-1
 SELINUX_MODE=$UNSELECTED_MODE
 
-$ZIP_FILE = $(basename $ZIP)
+ZIP_FILE=$(basename $ZIP)
 case $ZIP_FILE in
   *permissive*|*Permissive*|*PERMISSIVE*)
     SELINUX_MODE=0


### PR DESCRIPTION
Test: 'permissive' and 'enforcing' are fine now.
Change-Id: I7dca0adfa76681aac818f4f77a940abaaac86070